### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/3rd_party/sokol/sokol_gfx.h
+++ b/src/3rd_party/sokol/sokol_gfx.h
@@ -334,7 +334,7 @@
             a convenience function to get a sg_context_desc struct filled out
             with context information provided by sokol_app.h
 
-    See the documention block of the sg_desc struct below for more information.
+    See the documentation block of the sg_desc struct below for more information.
 
     BACKEND-SPECIFIC TOPICS:
     ========================

--- a/src/3rd_party/xatlas/xatlas.cpp
+++ b/src/3rd_party/xatlas/xatlas.cpp
@@ -5163,7 +5163,7 @@ struct Atlas
 					// Merge if chart2 has two faces (probably a quad), and chart1 bounds at least 2 of its edges.
 					if (chart2->faces.size() == 2 && m_sharedBoundaryEdgeCountNoSeams[cc] >= 2)
 						goto merge;
-					// Merge if chart2 is wholely inside chart1, ignoring seams.
+					// Merge if chart2 is wholly inside chart1, ignoring seams.
 					if (m_sharedBoundaryLengthsNoSeams[cc] > 0.0f && equal(m_sharedBoundaryLengthsNoSeams[cc], chart2->boundaryLength, kEpsilon))
 						goto merge;
 					if (m_sharedBoundaryLengths[cc] > 0.2f * max(0.0f, chart->boundaryLength - externalBoundaryLength) || 

--- a/src/golf/game.c
+++ b/src/golf/game.c
@@ -486,7 +486,7 @@ static void _physics_tick(float dt) {
             processed_vertices[num_processed_vertices++] = contact->triangle_c;
         }
 
-        // Remove uncessary point contacts
+        // Remove unnecessary point contacts
         for (int i = 0; i < num_contacts; i++) {
             golf_ball_contact_t *contact = &contacts[i];
             if (contact->is_ignored ||


### PR DESCRIPTION
There are small typos in:
- src/3rd_party/sokol/sokol_gfx.h
- src/3rd_party/xatlas/xatlas.cpp
- src/golf/game.c

Fixes:
- Should read `unnecessary` rather than `uncessary`.
- Should read `wholly` rather than `wholely`.
- Should read `documentation` rather than `documention`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md